### PR TITLE
[Bugfix] Type error, deep whois - Addresses #2, #3

### DIFF
--- a/src/whois.gtld.php
+++ b/src/whois.gtld.php
@@ -37,7 +37,7 @@ class gtld_handler extends WhoisClient
 	var $REG_FIELDS = array(
                         'Domain Name:' => 'regrinfo.domain.name',
                         'Registrar:' => 'regyinfo.registrar',
-                        'Whois Server:' => 'regyinfo.whois',
+                        'Registrar WHOIS Server:' => 'regyinfo.whois',
                         'Referral URL:' => 'regyinfo.referrer',
                         'Name Server:' => 'regrinfo.domain.nserver.',  // identical descriptors
 						'Updated Date:' => 'regrinfo.domain.changed',

--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -338,7 +338,7 @@ if (!$items)
 				'Zone Email:' => 'zone.email'
 				);
 
-$r = '';
+$r = [];
 $disok = true;
 
 while (list($key,$val) = each($rawdata))


### PR DESCRIPTION
Seems something happened in PHP 7-ish (currently running 7.1.19 on MacOS 10.14) that made the problem mentioned in issue #2 break this script.
Without setting `$r = []` I was unable to run the test suite, or even a basic example as below.
```php
<?php

include('src/whois.main.php');

$whois = new Whois();

$result = $whois->Lookup('google.com');
print_r($result);
```

PR also contains the changes mentioned in #3 , as I was unable to run the code at all with PHP 7 so the above change needed to be made first..

Not sure if this is likely to break anything with TLDs other than the .com/.net which I used for testing.