### PR TITLE
[Bugfix] Type error - Addresses #4

### DIFF
--- a/src/whois.gtld.php
+++ b/src/whois.gtld.php
@@ -54,7 +54,7 @@ class gtld_handler extends WhoisClient
 	function parse($data, $query)
 		{
 		$this->Query = array();
-		$this->SUBVERSION = sprintf('%s-%s', $query['handler'], $this->HANDLER_VERSION);
+		$this->SUBVERSION = sprintf('%s-%s', get_class($this), $this->HANDLER_VERSION);
 		$this->result = generic_parser_b($data['rawdata'], $this->REG_FIELDS, 'dmy');
 
 		unset($this->result['registered']);

--- a/src/whois.gtld.php
+++ b/src/whois.gtld.php
@@ -37,7 +37,7 @@ class gtld_handler extends WhoisClient
 	var $REG_FIELDS = array(
                         'Domain Name:' => 'regrinfo.domain.name',
                         'Registrar:' => 'regyinfo.registrar',
-                        'Whois Server:' => 'regyinfo.whois',
+                        'Registrar WHOIS Server:' => 'regyinfo.whois',
                         'Referral URL:' => 'regyinfo.referrer',
                         'Name Server:' => 'regrinfo.domain.nserver.',  // identical descriptors
 						'Updated Date:' => 'regrinfo.domain.changed',

--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -338,7 +338,7 @@ if (!$items)
 				'Zone Email:' => 'zone.email'
 				);
 
-$r = '';
+$r = [];
 $disok = true;
 
 while (list($key,$val) = each($rawdata))


### PR DESCRIPTION
Fixes #4 

In `src/whois.gtld.php:54  parse($data, $query)` the `$query` parameter appears to always be a string, but then is attempted to be accessed as an array. This doesn't work and that'd be why the warnings are seen.

I couldn't see any other uses of the `$this->SUBVERSION` attribute, but have set it to basically 'gtld_handler-VERSION' just in case it's required for whatever reason.