### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ or not and which is the registrar but not the owner information.
 
 ### UTF-8
 
-PHPWhois will assume that all whois servers resturn UTF-8 encoded output,
+PHPWhois will assume that all whois servers return UTF-8 encoded output,
 if some whois server does not return UTF-8 data, you can include it in
 the `NON_UTF8` array in whois.servers.php
 


### PR DESCRIPTION
Also, in the about section, there's also a typo in `soruces`.