### PR TITLE
example: HTML escape WHOIS registrant data

### DIFF
--- a/example.php
+++ b/example.php
@@ -66,7 +66,7 @@ if (isSet($_GET['query']))
 		case 'object':
 			if ($whois->Query['status'] < 0)
 				{
-				$winfo = implode($whois->Query['errstr'],"\n<br></br>");
+				$winfo = html_escape_and_implode($whois->Query['errstr'],"\n<br></br>");
 				}
 			else
 				{
@@ -84,7 +84,7 @@ if (isSet($_GET['query']))
 			else
 				{
 				if (isset($whois->Query['errstr']))
-					$winfo = implode($whois->Query['errstr'],"\n<br></br>");
+					$winfo = html_escape_and_implode($whois->Query['errstr'],"\n<br></br>");
 				else
 					$winfo = 'Unexpected error';
 				}
@@ -97,11 +97,11 @@ if (isSet($_GET['query']))
 		default:
 			if(!empty($result['rawdata']))
 				{
-				$winfo .= '<pre>'.implode($result['rawdata'],"\n").'</pre>';
+				$winfo .= '<pre>'.html_escape_and_implode($result['rawdata'], "\n").'</pre>';
 				}
 			else
 				{
-				$winfo = implode($whois->Query['errstr'],"\n<br></br>");
+				$winfo = html_escape_and_implode($whois->Query['errstr'],"\n<br></br>");
 				}
 		}
 
@@ -117,6 +117,21 @@ else
 exit(str_replace('{results}', $resout, $out));
 
 //-------------------------------------------------------------------------
+
+function html_escape_and_implode( $pieces, $glue ) 
+{	
+	$escaped_pieces = array();
+
+	if (is_string($pieces)) {
+		$pieces = array($pieces);
+	}
+
+	foreach ($pieces as $piece) {
+		array_push($escaped_pieces, htmlspecialchars($piece, ENT_QUOTES));
+	}
+
+	return implode( $glue, $escaped_pieces );
+}
 
 function extract_block (&$plantilla,$mark,$retmark='')
 {


### PR DESCRIPTION
## Issue

It is possible for WHOIS registrant data to include HTML tags. Many domain registrars will sanitise this input, however it is relatively simple to add HTML to the remarks section of WHOIS data if you control an Autonomous System or IP block.

The example script in this repo does not escape the `$result['rawdata']` and thus if HTML is included within the WHOIS response, it is directly rendered on the page if the script is invoked as follows `example.php?query=AS_NUMBER`.

I have reproduced this behaviour locally.

## What does this PR do?

- Escapes the `$result['rawdata']` to make sure that a WHOIS response does not cause HTML from that response to be rendered
- Additionally, escapes the Whois error results as a good precaution

## Example

For example, without the fix, this query can change the stying of the page to blue rather than white.

![image](https://user-images.githubusercontent.com/1413854/225023497-eccff6c7-0c67-4810-8119-863ef0f541d2.png)
